### PR TITLE
Security upgrades

### DIFF
--- a/ldap-sync/hooks/ordrd-group-x/Dockerfile
+++ b/ldap-sync/hooks/ordrd-group-x/Dockerfile
@@ -6,8 +6,6 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build -o ordrd-group-x main.go
 
 # Final stage
-FROM ubuntu:latest
+FROM ubuntu:20.04
 WORKDIR /app
-COPY --from=builder /app/ordrd-group-x .
-EXPOSE 5001
-ENTRYPOINT ["./ordrd-group-x"]
+RUN apt-get update && apt-get upgrade -y

--- a/ldap-sync/hooks/ordrd-group-x/Dockerfile
+++ b/ldap-sync/hooks/ordrd-group-x/Dockerfile
@@ -8,4 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o ordrd-group-x main.go
 # Final stage
 FROM ubuntu:20.04
 WORKDIR /app
+COPY --from=builder /app/ordrd-group-x .
 RUN apt-get update && apt-get upgrade -y
+EXPOSE 5001
+ENTRYPOINT ["./ordrd-group-x"]


### PR DESCRIPTION
lock to ubuntu 20.04 LTS and upgrade packages